### PR TITLE
Add filter option

### DIFF
--- a/config_form.php
+++ b/config_form.php
@@ -1,11 +1,10 @@
 <div class="field">
-    <div class="two columns alpha">
-        <label for="css"><?php echo __('CSS'); ?></label>    
-    </div>    
-    <div class="inputs five columns omega">
+    <label for="css"><?php echo __('CSS'); ?></label>    
         <p class="explanation"><?php echo __('The custom CSS you would like to add.'); ?></p>
         <div class="input-block">
             <?php echo get_view()->formTextarea('css', get_option('css_editor_css'), array('rows' => 25, 'cols' => 50)); ?>
         </div>
-    </div>
+
+        <label for="filter"><?php echo __('Filter CSS'); ?></label> 
+        <?php echo get_view()->formCheckbox('filter', null, array('checked' => get_option('css_editor_filter'))); ?>
 </div>

--- a/config_form.php
+++ b/config_form.php
@@ -1,10 +1,19 @@
 <div class="field">
-    <label for="css"><?php echo __('CSS'); ?></label>    
+    <div class="two columns alpha"> 
+        <label for="css"><?php echo __('CSS'); ?></label>
+    </div>
+    <div class="inputs five columns omega">   
         <p class="explanation"><?php echo __('The custom CSS you would like to add.'); ?></p>
         <div class="input-block">
             <?php echo get_view()->formTextarea('css', get_option('css_editor_css'), array('rows' => 25, 'cols' => 50)); ?>
         </div>
-
-        <label for="filter"><?php echo __('Filter CSS'); ?></label> 
+    </div>
+</div>
+<div class="field">
+    <div class="two columns alpha">
+        <label for="filter"><?php echo __('Filter CSS'); ?></label>
+    </div>
+    <div class="inputs five columns omega"> 
         <?php echo get_view()->formCheckbox('filter', null, array('checked' => get_option('css_editor_filter'))); ?>
+    </div>
 </div>


### PR DESCRIPTION
Hi all, 

As useful as the HTMLPurifier integration is, I always find myself fighting with it when using this plugin. This PR provides a simple check box which allows users to disable filtering. 

I recognize that this may be considered a security concern, but since only users with the super role have the ability to use this plugin anyway I think the risk is quite low.

Not sure if you'd be interested in this, but I thought I would pass it along regardless. 

Take care, 
-Adam
